### PR TITLE
Fix topnav logo path

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -58,7 +58,7 @@
   </head>
   <body>
     <div class="topnav">
-      <a href="https://en.westlake.edu.cn/"><img width="140" src="../assets/img/westlake.png"></a>
+      <a href="https://en.westlake.edu.cn/"><img width="140" src="./assets/img/westlake.png"></a>
       <div id="myLinks">
         <a class="normal right" href="./#contact">Contact</a>
         <a class="normal" href="./#publications">Publications</a>


### PR DESCRIPTION
## Summary
- fix the path for the Westlake logo image in the navigation bar

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(fails: `Net::HTTPClientException 403 "Forbidden"`)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9a38dc88332a36721435552ed3f