### PR TITLE
Fix image width style

### DIFF
--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -10,7 +10,7 @@
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
     {% if link.image %} 
-    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width=100;height=40%">
+    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width:100%; height:40%;">
     {% endif %}
     {% if link.journal_short %} 
     <abbr class="badge">{{ link.journal_short }}</abbr>
@@ -57,7 +57,7 @@
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
     {% if link.image %} 
-    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width=100;height=40%">
+    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width:100%; height:40%;">
     {% endif %}
     {% if link.conference_short %} 
     <abbr class="badge">{{ link.conference_short }}</abbr>
@@ -104,7 +104,7 @@
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
     {% if link.image %} 
-    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width=100;height=40%">
+    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width:100%; height:40%;">
     {% endif %}
     {% if link.journal_short %} 
     <abbr class="badge">{{ link.journal_short }}</abbr>


### PR DESCRIPTION
## Summary
- tweak inline style for images so width is `100%`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feb10824083329bb5b5f8d6c4d2f2