### PR TITLE
Fix includes filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Create `index.md` and add your personal information. It supports **Markdown** an
 
 ### Edit included files
 
-There are two markdown files included in `index.md`. They are `_includes/publications.md` and `_includes/service.md`, respectively. These two files also support **Markdown** and **HTML** syntax. If you don't hope to include these two files, you may remove the following lines in `index.md`:
+There are two markdown files included in `index.md`. They are `_includes/publications.md` and `_includes/services.md`, respectively. These two files also support **Markdown** and **HTML** syntax. If you don't hope to include these two files, you may remove the following lines in `index.md`:
 https://github.com/yaoyao-liu/minimal-light/blob/b38070cd0b6bce45d8a885f3828549af8f82b7cb/index.md?plain=1#L21-L23
 
 If you hope to edit the publication list without changing the format, you may edit `_data/publications.yml`:


### PR DESCRIPTION
## Summary
- update README reference to `_includes/services.md`

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683feb13e3f88332a455dda5ed6fc7a7